### PR TITLE
Improve site positioning and discovery metadata

### DIFF
--- a/content/extra/robots.txt
+++ b/content/extra/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow: /mahaclinic/
+
+Sitemap: https://sohailmo.ai/sitemap.xml

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -1,15 +1,18 @@
 Title: About
 Slug: about
+Summary: Sohail Mohammad is a forward deployed engineer at Together AI working on inference optimization, post-training, and production AI systems.
 
 ![with maha]({static}/images/maha-sohail.jpg)
 
-i'm sohail. i'm a forward deployed engineer at together ai, working on inference optimization and post-training with enterprise customers.
+I'm Sohail Mohammad, a forward deployed engineer at Together AI. I work with enterprise customers on inference optimization, post-training, and production AI systems where cost, latency, reliability, and quality all interact.
 
-before this i built agent platforms for 1.5m+ employees at amazon, a rag system at jpmorgan chase that went from 0 to 10k+ users, genai in the drive-thru at wendy's, gpu stuff at jack henry, and ml systems at capgemini.
+Before Together, I built AI and ML systems across large enterprise environments: agent platforms for 1.5M+ employees at Amazon, a JPMorgan Chase RAG system that grew from 0 to 10k+ users, GenAI drive-thru systems at Wendy's, GPU infrastructure at Jack Henry, and ML systems at Capgemini.
 
-i love my wife. i love the gym. i love our cats.
+My writing focuses on the parts of AI deployment that pricing pages and benchmarks miss: retries, evals, quality gates, routing, cache behavior, human escalation, and loaded cost per accepted result.
 
-contributed to unsloth, mlx-lm, and some rlhf stuff.
+I also publish research notes and negative results around post-training, activation steering, interpretability, and model behavior. I've contributed to Unsloth, mlx-lm, and RLHF-related tooling.
+
+I love my wife. I love the gym. I love our cats.
 
 [github](https://github.com/sohailm25) · [linkedin](https://linkedin.com/in/sohail-mo) · [x](https://x.com/Sohailm25)
 

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,12 +1,19 @@
 AUTHOR = "Sohail Mohammad"
 SITENAME = "Sohail Mohammad"
 SITEURL = ""
+CANONICAL_SITEURL = "https://sohailmo.ai"
+SITEDESCRIPTION = (
+    "Sohail Mohammad is a forward deployed engineer at Together AI writing about "
+    "production inference, post-training, AI infrastructure, and loaded cost per accepted result."
+)
+DEFAULT_OG_IMAGE = f"{CANONICAL_SITEURL}/theme/images/hero-avatar.jpg"
 
 PATH = "content"
 TIMEZONE = "America/Chicago"
 DEFAULT_LANG = "en"
 
-FEED_ALL_ATOM = None
+FEED_ALL_ATOM = "feed.xml"
+FEED_ALL_RSS = None
 CATEGORY_FEED_ATOM = None
 TRANSLATION_FEED_ATOM = None
 AUTHOR_FEED_ATOM = None
@@ -46,8 +53,10 @@ PAGE_URL = "pages/{slug}/"
 PAGE_SAVE_AS = "pages/{slug}/index.html"
 ARTICLE_URL = "{slug}/"
 ARTICLE_SAVE_AS = "{slug}/index.html"
-DIRECT_TEMPLATES = ("index", "archives")
+DIRECT_TEMPLATES = ("index", "archives", "sitemap", "llms")
 ARCHIVES_SAVE_AS = "writings/index.html"
+SITEMAP_SAVE_AS = "sitemap.xml"
+LLMS_SAVE_AS = "llms.txt"
 
 TAG_SAVE_AS = ""
 CATEGORY_SAVE_AS = ""

--- a/publishconf.py
+++ b/publishconf.py
@@ -8,6 +8,6 @@ SITEURL = "https://sohailmo.ai"
 RELATIVE_URLS = False
 DELETE_OUTPUT_DIRECTORY = True
 
-# Feeds stay disabled in production too
-FEED_ALL_ATOM = None
+# Site discovery surfaces
+FEED_ALL_ATOM = "feed.xml"
 CATEGORY_FEED_ATOM = None

--- a/scripts/clean_pandoc_artifacts.py
+++ b/scripts/clean_pandoc_artifacts.py
@@ -46,7 +46,8 @@ def fix_title_newlines(html: str) -> str:
     """Collapse \\n inside <title> and <h1>..<h6> tags to a single space."""
     def collapse(m: re.Match) -> str:
         tag_open, content, tag_close = m.group(1), m.group(2), m.group(3)
-        return f"{tag_open}{re.sub(r'\s*\n\s*', ' ', content)}{tag_close}"
+        collapsed = re.sub(r"\s*\n\s*", " ", content)
+        return f"{tag_open}{collapsed}{tag_close}"
 
     pattern = re.compile(
         r"(<(?:title|h[1-6])[^>]*>)(.*?)(</(?:title|h[1-6])>)",

--- a/theme/static/css/site.css
+++ b/theme/static/css/site.css
@@ -146,11 +146,87 @@ a:hover { color: var(--brown); text-decoration-color: var(--brown); }
   font-variation-settings: "opsz" 24;
   font-size: 1.2rem;
   color: var(--text-deck);
-  max-width: 48ch;
-  margin-bottom: var(--space-5);
+  max-width: 58ch;
+  margin-bottom: var(--space-3);
   line-height: 1.45;
 }
+.hero-detail {
+  font-size: 1rem;
+  color: var(--text-deck);
+  max-width: 66ch;
+  margin-bottom: var(--space-5);
+  line-height: 1.6;
+}
 .hero-actions { display: flex; gap: var(--space-3); flex-wrap: wrap; }
+.hero--positioning .hero-name { max-width: 16ch; }
+
+.proof-strip {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  margin: var(--space-5) 0 var(--space-3);
+}
+.proof-strip div {
+  padding: var(--space-3);
+  border-right: 1px solid var(--ink-soft);
+}
+.proof-strip div:last-child { border-right: 0; }
+.proof-strip strong {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--fs-mono-data);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink);
+  margin-bottom: var(--space-1);
+}
+.proof-strip span {
+  display: block;
+  font-size: 0.88rem;
+  line-height: 1.45;
+  color: var(--text-deck);
+}
+
+.start-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+.start-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-height: 220px;
+  padding: var(--space-4);
+  border: 1px solid var(--ink);
+  color: inherit;
+  text-decoration: none;
+  background: var(--paper-tint);
+}
+.start-card:hover { border-color: var(--brown); color: var(--text); }
+.start-card:hover strong { color: var(--brown); }
+.start-card-kicker {
+  font-family: var(--font-mono);
+  font-size: var(--fs-mono-meta);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink);
+}
+.start-card strong {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.55rem;
+  line-height: 1.15;
+  color: var(--text);
+  transition: color 0.15s;
+}
+.start-card span:last-child {
+  color: var(--text-deck);
+  line-height: 1.55;
+}
 
 /* ── Section top-rule ─────────────────────────── */
 .section-rule {
@@ -170,6 +246,12 @@ a:hover { color: var(--brown); text-decoration-color: var(--brown); }
   margin-bottom: var(--space-5);
 }
 .section-rule a { color: var(--ink); text-decoration: none; }
+.section-rule h1 {
+  font: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+}
 .section-rule a:hover { color: var(--brown); }
 
 /* ── Ruled list ───────────────────────────────── */
@@ -557,7 +639,13 @@ a:hover { color: var(--brown); text-decoration-color: var(--brown); }
   }
   .hero-image img { width: 120px; height: 120px; }
   .hero-name { font-size: 2.2rem; }
+  .hero--positioning .hero-name { max-width: 14ch; }
   .hero-bio { font-size: 1.05rem; }
+  .proof-strip { grid-template-columns: 1fr; }
+  .proof-strip div { border-right: 0; border-bottom: 1px solid var(--ink-soft); }
+  .proof-strip div:last-child { border-bottom: 0; }
+  .start-grid { grid-template-columns: 1fr; }
+  .start-card { min-height: 0; }
   .ruled-row { grid-template-columns: 1fr; gap: var(--space-1); }
   .ruled-date { font-size: var(--fs-mono-meta); }
   .subscribe-banner { flex-direction: column; align-items: flex-start; gap: var(--space-3); }

--- a/theme/templates/archives.html
+++ b/theme/templates/archives.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 
 {% block title %}Writings - {{ SITENAME }}{% endblock %}
+{% block meta_description %}Essays, research notes, case studies, and field notes from Sohail Mohammad on production AI infrastructure, inference economics, post-training, and adjacent thinking.{% endblock %}
+{% block canonical_url %}{{ CANONICAL_SITEURL }}/writings/{% endblock %}
+{% block og_title %}Writings - {{ SITENAME }}{% endblock %}
+{% block og_description %}Essays, research notes, case studies, and field notes from Sohail Mohammad on production AI infrastructure and inference economics.{% endblock %}
+{% block og_url %}{{ CANONICAL_SITEURL }}/writings/{% endblock %}
+{% block twitter_title %}Writings - {{ SITENAME }}{% endblock %}
+{% block twitter_description %}Essays, research notes, case studies, and field notes from Sohail Mohammad on production AI infrastructure and inference economics.{% endblock %}
 {% block nav_writings %} class="active" aria-current="page"{% endblock %}
 
 {% block content %}
@@ -17,14 +24,14 @@
   <a href="https://sohailmo.substack.com/subscribe" class="site-btn" target="_blank" rel="noopener">Subscribe ↗</a>
 </div>
 
-<div class="section-rule"><span>All Writings</span></div>
+<div class="section-rule"><h1>All Writings</h1></div>
 
-<div class="category-chips">
-  <button class="category-chip active" data-category="all" onclick="filterCategory('all')">All</button>
-  <button class="category-chip" data-category="Case Studies" onclick="filterCategory('Case Studies')">Case Studies</button>
-  <button class="category-chip" data-category="Notes &amp; Projects" onclick="filterCategory('Notes &amp; Projects')">Notes &amp; Projects</button>
-  <button class="category-chip" data-category="Thoughts" onclick="filterCategory('Thoughts')">Thoughts</button>
-  <button class="category-chip" data-category="Poems" onclick="filterCategory('Poems')">Poems</button>
+<div class="category-chips" aria-label="Filter writings by category">
+  <button class="category-chip active" data-category="all" aria-pressed="true" onclick="filterCategory('all')">All</button>
+  <button class="category-chip" data-category="Case Studies" aria-pressed="false" onclick="filterCategory('Case Studies')">Case Studies</button>
+  <button class="category-chip" data-category="Notes &amp; Projects" aria-pressed="false" onclick="filterCategory('Notes &amp; Projects')">Notes &amp; Projects</button>
+  <button class="category-chip" data-category="Thoughts" aria-pressed="false" onclick="filterCategory('Thoughts')">Thoughts</button>
+  <button class="category-chip" data-category="Poems" aria-pressed="false" onclick="filterCategory('Poems')">Poems</button>
 </div>
 
 <ul class="ruled-list" id="writings-list">
@@ -47,8 +54,11 @@
 
 <script>
 function filterCategory(category) {
-  document.querySelectorAll('.category-chip').forEach(c => c.classList.remove('active'));
-  document.querySelector(`[data-category="${category}"]`).classList.add('active');
+  document.querySelectorAll('.category-chip').forEach(c => {
+    const isActive = c.dataset.category === category;
+    c.classList.toggle('active', isActive);
+    c.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
   document.querySelectorAll('#writings-list .ruled-row').forEach(row => {
     row.style.display = (category === 'all' || row.dataset.category === category) ? '' : 'none';
   });

--- a/theme/templates/article.html
+++ b/theme/templates/article.html
@@ -1,6 +1,28 @@
 {% extends "base.html" %}
 
 {% block title %}{{ article.title }} - {{ SITENAME }}{% endblock %}
+{% block meta_description %}{{ article.summary|striptags|truncate(160)|e }}{% endblock %}
+{% block canonical_url %}{{ CANONICAL_SITEURL }}/{{ article.url }}{% endblock %}
+{% block og_type %}article{% endblock %}
+{% block og_title %}{{ article.title|e }} - {{ SITENAME }}{% endblock %}
+{% block og_description %}{{ article.summary|striptags|truncate(160)|e }}{% endblock %}
+{% block og_url %}{{ CANONICAL_SITEURL }}/{{ article.url }}{% endblock %}
+{% block twitter_title %}{{ article.title|e }} - {{ SITENAME }}{% endblock %}
+{% block twitter_description %}{{ article.summary|striptags|truncate(160)|e }}{% endblock %}
+{% block structured_data %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": {{ article.title|tojson }},
+  "description": {{ article.summary|striptags|truncate(160)|tojson }},
+  "url": "{{ CANONICAL_SITEURL }}/{{ article.url }}",
+  "datePublished": "{{ article.date.isoformat() }}",
+  "author": {"@type": "Person", "name": "Sohail Mohammad", "url": "{{ CANONICAL_SITEURL }}/"},
+  "publisher": {"@type": "Person", "name": "Sohail Mohammad", "url": "{{ CANONICAL_SITEURL }}/"}
+}
+</script>
+{% endblock %}
 {% block body_class %} class="post-page"{% endblock %}
 
 {% block content %}

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -4,7 +4,31 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}{{ SITENAME }}{% endblock %}</title>
-  <meta name="description" content="{{ SITEDESCRIPTION|default('') }}">
+  <meta name="description" content="{% block meta_description %}{{ SITEDESCRIPTION }}{% endblock %}">
+  <link rel="canonical" href="{% block canonical_url %}{{ CANONICAL_SITEURL }}/{% endblock %}">
+  <meta property="og:type" content="{% block og_type %}website{% endblock %}">
+  <meta property="og:title" content="{% block og_title %}{{ SITENAME }}{% endblock %}">
+  <meta property="og:description" content="{% block og_description %}{{ SITEDESCRIPTION }}{% endblock %}">
+  <meta property="og:url" content="{% block og_url %}{{ CANONICAL_SITEURL }}/{% endblock %}">
+  <meta property="og:image" content="{% block og_image %}{{ DEFAULT_OG_IMAGE }}{% endblock %}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{% block twitter_title %}{{ SITENAME }}{% endblock %}">
+  <meta name="twitter:description" content="{% block twitter_description %}{{ SITEDESCRIPTION }}{% endblock %}">
+  <meta name="twitter:image" content="{% block twitter_image %}{{ DEFAULT_OG_IMAGE }}{% endblock %}">
+  <link rel="alternate" type="application/atom+xml" title="{{ SITENAME }} feed" href="{{ CANONICAL_SITEURL }}/feed.xml">
+  {% block structured_data %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Sohail Mohammad",
+    "url": "{{ CANONICAL_SITEURL }}/",
+    "jobTitle": "Forward Deployed Engineer",
+    "worksFor": {"@type": "Organization", "name": "Together AI"},
+    "sameAs": [{% for name, url in SOCIAL if name != 'email' %}"{{ url }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+  }
+  </script>
+  {% endblock %}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,600;1,6..72,400&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap">

--- a/theme/templates/index.html
+++ b/theme/templates/index.html
@@ -1,29 +1,87 @@
 {% extends "base.html" %}
 
+{% block title %}Sohail Mohammad - Production AI Infrastructure{% endblock %}
+{% block meta_description %}Forward deployed engineer at Together AI working on production inference, post-training, and AI infrastructure. Essays on latency tails, evals, routing, GPU utilization, and loaded cost per accepted result.{% endblock %}
+{% block og_title %}Sohail Mohammad - Production AI Infrastructure{% endblock %}
+{% block og_description %}Forward deployed engineer at Together AI writing about production inference, post-training, AI infrastructure, and loaded cost per accepted result.{% endblock %}
+{% block twitter_title %}Sohail Mohammad - Production AI Infrastructure{% endblock %}
+{% block twitter_description %}Forward deployed engineer at Together AI writing about production inference, post-training, AI infrastructure, and loaded cost per accepted result.{% endblock %}
 {% block nav_home %} class="active" aria-current="page"{% endblock %}
 {% block body_class %} class="home-page"{% endblock %}
 
 {% block content %}
-<section class="hero">
+<section class="hero hero--positioning">
   <div class="hero-content">
-    <p class="hero-kicker">hi, i'm</p>
-    <h1 class="hero-name">Sohail Mohammad</h1>
-    <p class="hero-bio">Tech, AI infrastructure, and adjacent thinking. Notes from a working engineer.</p>
+    <p class="hero-kicker">Sohail Mohammad</p>
+    <h1 class="hero-name">Production AI infrastructure, after the demo works.</h1>
+    <p class="hero-bio">Forward deployed engineer at Together AI working on production inference, post-training, and AI infrastructure.</p>
+    <p class="hero-detail">I write about the parts of AI deployment that show up after the demo works: latency tails, retries, evals, routing, GPU utilization, quality gates, and loaded cost per accepted result.</p>
     <div class="hero-actions">
-      <a href="mailto:sohailmo.ai@gmail.com" class="site-btn">Contact</a>
-      <a href="https://sohailmo.substack.com/subscribe" class="site-btn site-btn--soft" target="_blank" rel="noopener">Subscribe ↗</a>
+      <a href="{{ SITEURL }}/pages/inference-economics/" class="site-btn">Inference Economics</a>
+      <a href="/inference-field-guide/" class="site-btn site-btn--soft">Read the Field Guide</a>
+      <a href="mailto:sohailmo.ai@gmail.com" class="site-btn site-btn--soft">Email</a>
     </div>
   </div>
   <div class="hero-image">
-    <img src="{{ SITEURL }}/theme/images/hero-avatar.jpg" alt="">
+    <img src="{{ SITEURL }}/theme/images/hero-avatar.jpg" alt="" width="180" height="180" fetchpriority="high" decoding="async">
   </div>
 </section>
 
+<section class="proof-strip" aria-label="Selected proof points">
+  <div><strong>Together AI</strong><span>Inference optimization and post-training with enterprise customers</span></div>
+  <div><strong>Amazon</strong><span>Agent platforms for 1.5M+ employees</span></div>
+  <div><strong>JPMorgan Chase</strong><span>RAG system from 0 to 10k+ users</span></div>
+  <div><strong>Wendy's</strong><span>GenAI drive-thru systems</span></div>
+  <div><strong>Jack Henry</strong><span>GPU infrastructure</span></div>
+</section>
+
+<div class="section-rule"><span>Start Here</span></div>
+<div class="start-grid">
+  <a class="start-card" href="{{ SITEURL }}/pages/inference-economics/">
+    <span class="start-card-kicker">Flagship</span>
+    <strong>Production Inference Economics</strong>
+    <span>A field guide, calculator, and essay series for measuring AI systems by loaded cost per accepted result.</span>
+  </a>
+  <a class="start-card" href="/inference-field-guide/">
+    <span class="start-card-kicker">Book</span>
+    <strong>The Honest Field Guide to Production Inference</strong>
+    <span>How to reason about provider choice, routing, retries, quality gates, serving, and migration economics.</span>
+  </a>
+  <a class="start-card" href="https://inference-econ.streamlit.app/" target="_blank" rel="noopener">
+    <span class="start-card-kicker">Tool</span>
+    <strong>LCPR Calculator ↗</strong>
+    <span>Run the loaded-cost math on your own workload instead of trusting token-price theater.</span>
+  </a>
+</div>
+
+{% set inference_slugs = ['goodput', 'denominator-problem', 'workload-costs', 'trace-autopsy'] %}
+{% set inference_articles = articles|selectattr('slug', 'in', inference_slugs)|list %}
+{% if inference_articles %}
+<div class="section-rule">
+  <span>Inference Economics</span>
+  <a href="{{ SITEURL }}/pages/inference-economics/">see all →</a>
+</div>
+<ul class="ruled-list">
+  {% for article in inference_articles %}
+  <li class="ruled-row">
+    <a href="{{ SITEURL }}/{{ article.url }}">
+      <span class="ruled-date">{{ article.date.strftime('%Y-%m-%d') }}</span>
+      <div class="ruled-body">
+        <div class="ruled-title">{{ article.title }}</div>
+        <div class="ruled-excerpt">{{ article.summary|striptags|truncate(180) }}</div>
+        <div class="ruled-meta">{{ article.category }}</div>
+      </div>
+    </a>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+
 {% set featured_articles = articles|selectattr('featured', 'defined')|selectattr('featured')|list %}
 {% if featured_articles %}
-<div class="section-rule"><span>Featured</span></div>
+<div class="section-rule"><span>Selected Work</span></div>
 <ul class="ruled-list">
-  {% for article in featured_articles %}
+  {% for article in featured_articles[:4] %}
   <li class="ruled-row">
     <a href="{{ SITEURL }}/{{ article.url }}">
       <span class="ruled-date">{{ article.date.strftime('%Y-%m-%d') }}</span>

--- a/theme/templates/inference-economics.html
+++ b/theme/templates/inference-economics.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 
 {% block title %}{{ page.title }} - {{ SITENAME }}{% endblock %}
+{% block meta_description %}{{ page.summary|striptags|truncate(160)|e if page.summary else SITEDESCRIPTION }}{% endblock %}
+{% block canonical_url %}{{ CANONICAL_SITEURL }}/{{ page.url }}{% endblock %}
+{% block og_title %}{{ page.title|e }} - {{ SITENAME }}{% endblock %}
+{% block og_description %}{{ page.summary|striptags|truncate(160)|e if page.summary else SITEDESCRIPTION }}{% endblock %}
+{% block og_url %}{{ CANONICAL_SITEURL }}/{{ page.url }}{% endblock %}
+{% block twitter_title %}{{ page.title|e }} - {{ SITENAME }}{% endblock %}
+{% block twitter_description %}{{ page.summary|striptags|truncate(160)|e if page.summary else SITEDESCRIPTION }}{% endblock %}
 {% block body_class %} class="post-page"{% endblock %}
 {% block nav_inference_economics %} class="active" aria-current="page"{% endblock %}
 

--- a/theme/templates/llms.html
+++ b/theme/templates/llms.html
@@ -1,0 +1,25 @@
+# Sohail Mohammad
+
+Sohail Mohammad is a forward deployed engineer at Together AI working on production inference, post-training, and AI infrastructure.
+
+## Core pages
+
+- Home: {{ CANONICAL_SITEURL }}/
+- About: {{ CANONICAL_SITEURL }}/pages/about/
+- Writings: {{ CANONICAL_SITEURL }}/writings/
+- Research: {{ CANONICAL_SITEURL }}/pages/research/
+- Inference Economics: {{ CANONICAL_SITEURL }}/pages/inference-economics/
+
+## Start here
+
+- The Honest Field Guide to Production Inference: {{ CANONICAL_SITEURL }}/inference-field-guide/
+- Goodput or It Didn't Happen: {{ CANONICAL_SITEURL }}/goodput/
+- The Denominator Problem: {{ CANONICAL_SITEURL }}/denominator-problem/
+- What Your Workload Actually Costs: {{ CANONICAL_SITEURL }}/workload-costs/
+- LCPR Calculator: https://inference-econ.streamlit.app/
+
+## Recent writing
+
+{% for article in articles[:20] -%}
+- {{ article.title }}: {{ CANONICAL_SITEURL }}/{{ article.url }}
+{% endfor %}

--- a/theme/templates/longform_article.html
+++ b/theme/templates/longform_article.html
@@ -1,6 +1,28 @@
 {% extends "base.html" %}
 
 {% block title %}{{ article.title }} - {{ SITENAME }}{% endblock %}
+{% block meta_description %}{{ article.summary|striptags|truncate(160)|e }}{% endblock %}
+{% block canonical_url %}{{ CANONICAL_SITEURL }}/{{ article.url }}{% endblock %}
+{% block og_type %}article{% endblock %}
+{% block og_title %}{{ article.title|e }} - {{ SITENAME }}{% endblock %}
+{% block og_description %}{{ article.summary|striptags|truncate(160)|e }}{% endblock %}
+{% block og_url %}{{ CANONICAL_SITEURL }}/{{ article.url }}{% endblock %}
+{% block twitter_title %}{{ article.title|e }} - {{ SITENAME }}{% endblock %}
+{% block twitter_description %}{{ article.summary|striptags|truncate(160)|e }}{% endblock %}
+{% block structured_data %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": {{ article.title|tojson }},
+  "description": {{ article.summary|striptags|truncate(160)|tojson }},
+  "url": "{{ CANONICAL_SITEURL }}/{{ article.url }}",
+  "datePublished": "{{ article.date.isoformat() }}",
+  "author": {"@type": "Person", "name": "Sohail Mohammad", "url": "{{ CANONICAL_SITEURL }}/"},
+  "publisher": {"@type": "Person", "name": "Sohail Mohammad", "url": "{{ CANONICAL_SITEURL }}/"}
+}
+</script>
+{% endblock %}
 {% block body_class %} class="post-page longform-page"{% endblock %}
 
 {% block content %}

--- a/theme/templates/page.html
+++ b/theme/templates/page.html
@@ -1,6 +1,24 @@
 {% extends "base.html" %}
 
 {% block title %}{{ page.title }} - {{ SITENAME }}{% endblock %}
+{% block meta_description %}{{ page.summary|striptags|truncate(160)|e if page.summary else SITEDESCRIPTION }}{% endblock %}
+{% block canonical_url %}{{ CANONICAL_SITEURL }}/{{ page.url }}{% endblock %}
+{% block og_title %}{{ page.title|e }} - {{ SITENAME }}{% endblock %}
+{% block og_description %}{{ page.summary|striptags|truncate(160)|e if page.summary else SITEDESCRIPTION }}{% endblock %}
+{% block og_url %}{{ CANONICAL_SITEURL }}/{{ page.url }}{% endblock %}
+{% block twitter_title %}{{ page.title|e }} - {{ SITENAME }}{% endblock %}
+{% block twitter_description %}{{ page.summary|striptags|truncate(160)|e if page.summary else SITEDESCRIPTION }}{% endblock %}
+{% block structured_data %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": {{ page.title|tojson }},
+  "description": {{ (page.summary|striptags|truncate(160) if page.summary else SITEDESCRIPTION)|tojson }},
+  "url": "{{ CANONICAL_SITEURL }}/{{ page.url }}"
+}
+</script>
+{% endblock %}
 {% block body_class %} class="post-page"{% endblock %}
 {% block nav_about %}{% if page.slug == 'about' %} class="active" aria-current="page"{% endif %}{% endblock %}
 {% block nav_research %}{% if page.slug == 'research' %} class="active" aria-current="page"{% endif %}{% endblock %}

--- a/theme/templates/sitemap.html
+++ b/theme/templates/sitemap.html
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>{{ CANONICAL_SITEURL }}/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>{{ CANONICAL_SITEURL }}/writings/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+{% for page in pages %}
+  <url>
+    <loc>{{ CANONICAL_SITEURL }}/{{ page.url }}</loc>
+    {% if page.modified %}<lastmod>{{ page.modified.strftime('%Y-%m-%d') }}</lastmod>{% endif %}
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+{% endfor %}
+{% for article in articles %}
+  <url>
+    <loc>{{ CANONICAL_SITEURL }}/{{ article.url }}</loc>
+    <lastmod>{{ article.modified.strftime('%Y-%m-%d') if article.modified else article.date.strftime('%Y-%m-%d') }}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+{% endfor %}
+</urlset>

--- a/theme/templates/theforge.html
+++ b/theme/templates/theforge.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 
 {% block title %}The Forge - {{ SITENAME }}{% endblock %}
+{% block meta_description %}The Forge is Sohail Mohammad's weekly dispatch on AI, ML, systems, and the technical developments worth paying attention to.{% endblock %}
+{% block canonical_url %}{{ CANONICAL_SITEURL }}/theforge/{% endblock %}
+{% block og_title %}The Forge - {{ SITENAME }}{% endblock %}
+{% block og_description %}Sohail Mohammad's weekly dispatch on AI, ML, systems, and technical developments worth paying attention to.{% endblock %}
+{% block og_url %}{{ CANONICAL_SITEURL }}/theforge/{% endblock %}
+{% block twitter_title %}The Forge - {{ SITENAME }}{% endblock %}
+{% block twitter_description %}Sohail Mohammad's weekly dispatch on AI, ML, systems, and technical developments worth paying attention to.{% endblock %}
 {% block nav_writings %} class="active" aria-current="page"{% endblock %}
 
 {% block content %}

--- a/theme/templates/videos.html
+++ b/theme/templates/videos.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 
 {% block title %}Videos - {{ SITENAME }}{% endblock %}
+{% block meta_description %}Videos from Sohail Mohammad on AI systems, software development, and technical workflows.{% endblock %}
+{% block canonical_url %}{{ CANONICAL_SITEURL }}/pages/videos/{% endblock %}
+{% block og_title %}Videos - {{ SITENAME }}{% endblock %}
+{% block og_description %}Videos from Sohail Mohammad on AI systems, software development, and technical workflows.{% endblock %}
+{% block og_url %}{{ CANONICAL_SITEURL }}/pages/videos/{% endblock %}
+{% block twitter_title %}Videos - {{ SITENAME }}{% endblock %}
+{% block twitter_description %}Videos from Sohail Mohammad on AI systems, software development, and technical workflows.{% endblock %}
 {% block body_class %} class="post-page"{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- Reposition homepage around production AI infrastructure and inference economics
- Add proof strip, Start Here cards, and tighter About copy
- Add canonical/meta/OG/Twitter/JSON-LD metadata plus sitemap, feed, llms.txt, and robots sitemap reference
- Improve Writings archive H1/filter accessibility
- Fix Python 3.11 f-string syntax issue in clean_pandoc_artifacts.py

## Verification
- `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m pelican content -s publishconf.py -o output`
- metadata/discovery assertion script passed
- `uv run pytest -q` → 124 passed in 15.07s