### PR TITLE
Revise homepage hero copy

### DIFF
--- a/theme/templates/index.html
+++ b/theme/templates/index.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}Sohail Mohammad - Production AI Infrastructure{% endblock %}
-{% block meta_description %}Forward deployed engineer at Together AI working on production inference, post-training, and AI infrastructure. Essays on latency tails, evals, routing, GPU utilization, and loaded cost per accepted result.{% endblock %}
-{% block og_title %}Sohail Mohammad - Production AI Infrastructure{% endblock %}
-{% block og_description %}Forward deployed engineer at Together AI writing about production inference, post-training, AI infrastructure, and loaded cost per accepted result.{% endblock %}
-{% block twitter_title %}Sohail Mohammad - Production AI Infrastructure{% endblock %}
-{% block twitter_description %}Forward deployed engineer at Together AI writing about production inference, post-training, AI infrastructure, and loaded cost per accepted result.{% endblock %}
+{% block title %}Sohail Mohammad - Production AI Infra & Adjacent Thoughts{% endblock %}
+{% block meta_description %}Forward deployed engineer at Together AI. Notes on production AI infrastructure, inference economics, post-training, systems, and adjacent thoughts.{% endblock %}
+{% block og_title %}Sohail Mohammad - Production AI Infra & Adjacent Thoughts{% endblock %}
+{% block og_description %}Forward deployed engineer at Together AI. Notes on production AI infrastructure, inference economics, post-training, systems, and adjacent thoughts.{% endblock %}
+{% block twitter_title %}Sohail Mohammad - Production AI Infra & Adjacent Thoughts{% endblock %}
+{% block twitter_description %}Forward deployed engineer at Together AI. Notes on production AI infrastructure, inference economics, post-training, systems, and adjacent thoughts.{% endblock %}
 {% block nav_home %} class="active" aria-current="page"{% endblock %}
 {% block body_class %} class="home-page"{% endblock %}
 
@@ -13,9 +13,8 @@
 <section class="hero hero--positioning">
   <div class="hero-content">
     <p class="hero-kicker">Sohail Mohammad</p>
-    <h1 class="hero-name">Production AI infrastructure, after the demo works.</h1>
-    <p class="hero-bio">Forward deployed engineer at Together AI working on production inference, post-training, and AI infrastructure.</p>
-    <p class="hero-detail">I write about the parts of AI deployment that show up after the demo works: latency tails, retries, evals, routing, GPU utilization, quality gates, and loaded cost per accepted result.</p>
+    <h1 class="hero-name">Production AI Infra &amp; Adjacent Thoughts</h1>
+    <p class="hero-bio">Forward deployed engineer at Together AI. Notes on inference economics, post-training, systems, and adjacent thoughts.</p>
     <div class="hero-actions">
       <a href="{{ SITEURL }}/pages/inference-economics/" class="site-btn">Inference Economics</a>
       <a href="/inference-field-guide/" class="site-btn site-btn--soft">Read the Field Guide</a>


### PR DESCRIPTION
## Summary
- Change homepage hero to “Production AI Infra & Adjacent Thoughts”
- Remove the “after the demo” framing and related paragraph
- Soften homepage metadata to match the more natural voice

## Verification
- Pelican production build passed
- Hero assertion script passed
- `uv run pytest -q` → 124 passed