### PR TITLE
Update homepage positioning copy

### DIFF
--- a/theme/templates/index.html
+++ b/theme/templates/index.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}Sohail Mohammad - Production AI Infra & Adjacent Thoughts{% endblock %}
-{% block meta_description %}Forward deployed engineer at Together AI. Notes on production AI infrastructure, inference economics, post-training, systems, and adjacent thoughts.{% endblock %}
-{% block og_title %}Sohail Mohammad - Production AI Infra & Adjacent Thoughts{% endblock %}
-{% block og_description %}Forward deployed engineer at Together AI. Notes on production AI infrastructure, inference economics, post-training, systems, and adjacent thoughts.{% endblock %}
-{% block twitter_title %}Sohail Mohammad - Production AI Infra & Adjacent Thoughts{% endblock %}
-{% block twitter_description %}Forward deployed engineer at Together AI. Notes on production AI infrastructure, inference economics, post-training, systems, and adjacent thoughts.{% endblock %}
+{% block title %}Sohail Mohammad - Production AI and Adjacent Thoughts{% endblock %}
+{% block meta_description %}Forward deployed engineer at Together AI. Notes on production AI and adjacent thoughts.{% endblock %}
+{% block og_title %}Sohail Mohammad - Production AI and Adjacent Thoughts{% endblock %}
+{% block og_description %}Forward deployed engineer at Together AI. Notes on production AI and adjacent thoughts.{% endblock %}
+{% block twitter_title %}Sohail Mohammad - Production AI and Adjacent Thoughts{% endblock %}
+{% block twitter_description %}Forward deployed engineer at Together AI. Notes on production AI and adjacent thoughts.{% endblock %}
 {% block nav_home %} class="active" aria-current="page"{% endblock %}
 {% block body_class %} class="home-page"{% endblock %}
 
@@ -13,8 +13,8 @@
 <section class="hero hero--positioning">
   <div class="hero-content">
     <p class="hero-kicker">Sohail Mohammad</p>
-    <h1 class="hero-name">Production AI Infra &amp; Adjacent Thoughts</h1>
-    <p class="hero-bio">Forward deployed engineer at Together AI. Notes on inference economics, post-training, systems, and adjacent thoughts.</p>
+    <h1 class="hero-name">Production AI and Adjacent Thoughts</h1>
+    <p class="hero-bio">Forward deployed engineer at Together AI. Notes on production AI and adjacent thoughts.</p>
     <div class="hero-actions">
       <a href="{{ SITEURL }}/pages/inference-economics/" class="site-btn">Inference Economics</a>
       <a href="{{ SITEURL }}/book/" class="site-btn site-btn--soft">Read the Field Guide</a>


### PR DESCRIPTION
## Summary
- Change homepage positioning from "Production AI Infra & Adjacent Thoughts" to "Production AI and Adjacent Thoughts"
- Simplify homepage meta/social descriptions to match

## Verification
- Pelican production build passed
- Positioning copy assertion script passed
- `uv run pytest -q` → 124 passed