### PR TITLE
Add subtle TikTok link to homepage

### DIFF
--- a/theme/static/css/site.css
+++ b/theme/static/css/site.css
@@ -158,6 +158,19 @@ a:hover { color: var(--brown); text-decoration-color: var(--brown); }
   line-height: 1.6;
 }
 .hero-actions { display: flex; gap: var(--space-3); flex-wrap: wrap; }
+.hero-social {
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  letter-spacing: 0.02em;
+  color: var(--text-muted);
+}
+.hero-social a {
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+}
 .hero--positioning .hero-name { max-width: 16ch; }
 
 .proof-strip {

--- a/theme/templates/index.html
+++ b/theme/templates/index.html
@@ -20,6 +20,7 @@
       <a href="{{ SITEURL }}/book/" class="site-btn site-btn--soft">Read the Field Guide</a>
       <a href="mailto:sohailmo.ai@gmail.com" class="site-btn site-btn--soft">Email</a>
     </div>
+    <p class="hero-social">Also making short-form AI explainers on <a href="https://www.tiktok.com/@sohailm25" target="_blank" rel="noopener">TikTok</a>.</p>
   </div>
   <div class="hero-image">
     <img src="{{ SITEURL }}/theme/images/hero-avatar.jpg" alt="" width="180" height="180" fetchpriority="high" decoding="async">


### PR DESCRIPTION
## Summary
- Add a subtle hero note linking to TikTok for short-form AI explainers
- Style the note as small monospace secondary text so it does not compete with primary CTAs

## Verification
- Pelican production build passed
- Homepage TikTok link assertion script passed
- `uv run pytest -q` → 124 passed