### PR TITLE
Diversify selected work

### DIFF
--- a/content/denominator-problem.md
+++ b/content/denominator-problem.md
@@ -3,7 +3,6 @@ Date: 2026-04-15
 Category: Writings
 Slug: denominator-problem
 Summary: The most common mistake in inference economics is dividing by the wrong number. LCPR (loaded cost per accepted result) reveals a 12x gap between naive token cost and actual production cost.
-Featured: true
 Template: longform_article
 Status: published
 

--- a/content/goodput.md
+++ b/content/goodput.md
@@ -3,7 +3,6 @@ Date: 2026-05-13
 Category: Writings
 Slug: goodput
 Summary: GPU utilization can be 78% while 30% of requests fail SLO constraints. The goodput frontier test replaces single-number benchmarks with decision-grade surfaces that measure accepted results, not raw throughput.
-Featured: true
 Template: longform_article
 Status: published
 

--- a/content/idiot-index-ai-deployment.md
+++ b/content/idiot-index-ai-deployment.md
@@ -4,6 +4,7 @@ Author: Sohail Mohammad
 Category: Essays
 Slug: idiot-index-ai-deployment
 Summary: The gap between what a model is supposed to do and what it actually does in production is enormous. Forward-deployed engineering exists to close it. Here's why i left Amazon for inference.
+Featured: true
 
 ---
 

--- a/content/inference-field-guide.md
+++ b/content/inference-field-guide.md
@@ -3,7 +3,6 @@ Date: 2026-04-08
 Category: Writings
 Slug: inference-field-guide
 Summary: TCO frameworks, vendor evaluation, and architecture patterns for teams adopting open-model inference. Includes the LCPR calculator, migration gates, and a staged playbook from API to dedicated GPU.
-Featured: true
 Template: longform_article
 Status: published
 

--- a/content/inference-flexibility-starts-in-the-api.md
+++ b/content/inference-flexibility-starts-in-the-api.md
@@ -3,6 +3,7 @@ Date: 2026-06-08
 Category: Writings
 Slug: inference-flexibility-starts-in-the-api
 Summary: A response to Mario Souto's clay jar essay: energy orchestration only works if inference systems expose workload class, latency tolerance, and value per accepted result.
+Featured: true
 Template: longform_article
 
 

--- a/content/lcpr-calculator-v2.md
+++ b/content/lcpr-calculator-v2.md
@@ -3,7 +3,6 @@ Date: 2026-04-29
 Category: Writings
 Slug: lcpr-calculator-v2
 Summary: Open-source calculator for loaded cost per result. Three worked examples, cache break-even analysis, and KV memory sizing.
-Featured: true
 Template: longform_article
 Status: published
 

--- a/content/rag-infrastructure-pgvector.md
+++ b/content/rag-infrastructure-pgvector.md
@@ -3,6 +3,7 @@ Date: 2026-01-31 12:00
 Category: Case Studies
 Slug: rag-infrastructure-pgvector
 Summary: Patterns and tradeoffs from building RAG infrastructure in regulated environments.
+Featured: true
 
 **Disclaimer:** This post reflects general patterns and lessons learned from building enterprise RAG systems. Technical details have been generalized, and no proprietary information from any specific organization is disclosed.
 

--- a/content/trace-autopsy.md
+++ b/content/trace-autopsy.md
@@ -3,7 +3,6 @@ Date: 2026-04-22
 Category: Writings
 Slug: trace-autopsy
 Summary: A repeatable diagnostic for going from raw trace events to loaded cost per accepted result. Twelve requests, four data sources, five cost mechanisms, and the reconciliation protocol.
-Featured: true
 Template: longform_article
 Status: published
 

--- a/content/vllm-production-scale-lessons.md
+++ b/content/vllm-production-scale-lessons.md
@@ -3,6 +3,7 @@ Date: 2026-02-03 14:00
 Category: Case Studies
 Slug: vllm-production-scale-lessons
 Summary: Memory fragmentation, throughput cliffs, and quantization accuracy issues that only show up in production—lessons from running vLLM at scale for conversational AI.
+Featured: true
 
 ---
 

--- a/content/workload-costs.md
+++ b/content/workload-costs.md
@@ -3,7 +3,6 @@ Date: 2026-05-06
 Category: Writings
 Slug: workload-costs
 Summary: Not all inference is the same. Per-workload LCPR exposes the cross-subsidy that blended averages hide, with cost models for conversational, agentic, RAG, extraction, voice, and batch workloads.
-Featured: true
 Template: longform_article
 Status: published
 


### PR DESCRIPTION
## Summary
- Feature the new inference flexibility essay on the homepage
- Remove the Inference Economics series pieces from Selected Work so that section is not redundant with the Inference Economics page
- Keep Selected Work focused on a more diverse set: new essay, Idiot Index, Ray production lessons, and vLLM production lessons

## Verification
- Production Pelican build passed: 47 articles, 0 drafts
- Homepage assertion passed: Selected Work has the expected four diverse entries
- Asserted Inference Economics series entries are not in Selected Work
- uv run pytest -q: 124 passed